### PR TITLE
Moved edittime as parameter and let it be null

### DIFF
--- a/src/commonMain/kotlin/ShoppingListItem.kt
+++ b/src/commonMain/kotlin/ShoppingListItem.kt
@@ -2,14 +2,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.datetime.*
 
 @Serializable
-data class ShoppingListItem(val desc: String, val priority: Int, val creationTime:Instant ) {
+data class ShoppingListItem(val desc: String, val priority: Int, val creationTime:Instant?, val lastEditTime:Instant? ) {
     val id: Int = desc.hashCode()
-    val lastEditTime:Instant=getCurrentDateTime()
     companion object {
         const val path = "/shoppingList"
     }
 }
-
 
 @Serializable
 data class User(val username: String, val password: String) {
@@ -21,11 +19,11 @@ data class User(val username: String, val password: String) {
     }
 }
 fun getShoppingListInfo():ShoppingListItem{
-    return ShoppingListItem("banana",1,getCurrentDateTime())
+    return ShoppingListItem("banana",1,getCurrentDateTime(),null)
 }
 fun getDummyShoppingList(): Collection<ShoppingListItem>{
-    val item = ShoppingListItem("Apples",5,getCurrentDateTime())
-    val item2 = ShoppingListItem("Oranges",5,getCurrentDateTime())
+    val item = ShoppingListItem("Apples",5,getCurrentDateTime(), null)
+    val item2 = ShoppingListItem("Oranges",5,getCurrentDateTime(),null )
 
     return listOf(item, item2)
 
@@ -37,10 +35,14 @@ fun getCurrentDateTime(): Instant {
     return currentMoment
 }
 
-fun convertDateTime(currentMoment: Instant):String  {
+fun convertDateTime(currentMoment: Instant?):String  {
+        return if(currentMoment==null) {
+        "N/A"
+    }
+    else {
         var day=currentMoment.toLocalDateTime(TimeZone.currentSystemDefault()).dayOfMonth.toString()
         var month= currentMoment.toLocalDateTime(TimeZone.currentSystemDefault()).monthNumber.toString()
         var year= currentMoment.toLocalDateTime(TimeZone.currentSystemDefault()).year.toString()
         var time= currentMoment.toLocalDateTime(TimeZone.currentSystemDefault()).time.toString().take(8)
-        return "Date: $month-$day-$year Time: $time"
+        return "Date: $month-$day-$year Time: $time"}
 }

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -49,7 +49,7 @@ val App = FC<Props> {
     }
     inputComponent {
         onSubmit = { input ->
-            val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' },getCurrentDateTime())
+            val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' },getCurrentDateTime(),null)
             scope.launch {
                 addShoppingListItem(cartItem)
                 shoppingList = getShoppingList()
@@ -94,7 +94,7 @@ val App = FC<Props> {
                     //print as a textfield
                     editComponent{
                         onSubmit = { input->
-                            val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' },item.creationTime)
+                            val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' },item.creationTime,getCurrentDateTime())
                             scope.launch {
                                 editShoppingListItem(item,cartItem)
                                 shoppingList = getShoppingList()


### PR DESCRIPTION
Both creationtime and edittime can be null. I let them be parameters because they would autoinitialize otherwise. We create new objects when we edit an item so that is why creationtime needs to be passed as a parameter. 

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/36392692/203176072-ce4f2bfb-b95e-4a49-9637-4eea48f6f868.png">

Closes #23