### PR TITLE
made id more unique

### DIFF
--- a/src/commonMain/kotlin/ShoppingListItem.kt
+++ b/src/commonMain/kotlin/ShoppingListItem.kt
@@ -1,9 +1,10 @@
 import kotlinx.serialization.Serializable
 import kotlinx.datetime.*
+import kotlin.random.Random
 
 @Serializable
 data class ShoppingListItem(val desc: String, val priority: Int, val creationTime:Instant ) {
-    val id: Int = desc.hashCode()
+    val id: Int = desc.hashCode()+ Random.nextInt(0, 100)
     val lastEditTime:Instant=getCurrentDateTime()
     companion object {
         const val path = "/shoppingList"


### PR DESCRIPTION
Trivial fix. The ID would be exactly the same if the string was the same. Simply adding a random number to be added to ID to make it more unique. Not a perfect fix but for our purposes its fine.

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/36392692/203177796-50261e29-147e-4491-8c20-b93776b4ea34.png">
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/36392692/203177840-f3267742-a42b-4f3f-9e93-3cab13890554.png">
These images show no issues deleting.

Closes #19 