### PR TITLE
Jupad002/accurate textfield

### DIFF
--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -93,6 +93,7 @@ val App = FC<Props> {
                 if(item==selectedEditItem) {
                     //print as a textfield
                     editComponent{
+                        name=item.desc
                         onSubmit = { input->
                             val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' },item.creationTime)
                             scope.launch {

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -93,7 +93,7 @@ val App = FC<Props> {
                 if(item==selectedEditItem) {
                     //print as a textfield
                     editComponent{
-                        name=item.desc
+                        listItem=item
                         onSubmit = { input->
                             val cartItem = ShoppingListItem(input.replace("!", ""), input.count { it == '!' },item.creationTime)
                             scope.launch {

--- a/src/jsMain/kotlin/InputComponent.kt
+++ b/src/jsMain/kotlin/InputComponent.kt
@@ -16,6 +16,12 @@ import react.dom.html.ReactHTML.button
 
 external interface InputProps : Props {
     var onSubmit: (String) -> Unit
+    var name:(String)
+}
+external interface EditProps : Props {
+    var onSubmit: (String) -> Unit
+    var name:(String)
+
 }
 
 val inputComponent = FC<InputProps> { props ->
@@ -43,7 +49,7 @@ val inputComponent = FC<InputProps> { props ->
 }
 private val scope = MainScope()
 
-val editComponent = FC<InputProps> { props ->
+val editComponent = FC<EditProps> { props ->
     val (text, setText) = useState("")
     val submitHandler: FormEventHandler<HTMLFormElement> = {
         it.preventDefault()
@@ -66,7 +72,7 @@ val editComponent = FC<InputProps> { props ->
         input {
             type = InputType.text
             onChange = changeHandler
-            value = text
+            value = props.name
         }
     }
 }

--- a/src/jsMain/kotlin/InputComponent.kt
+++ b/src/jsMain/kotlin/InputComponent.kt
@@ -16,11 +16,10 @@ import react.dom.html.ReactHTML.button
 
 external interface InputProps : Props {
     var onSubmit: (String) -> Unit
-    var name:(String)
 }
 external interface EditProps : Props {
     var onSubmit: (String) -> Unit
-    var name:(String)
+    var listItem:(ShoppingListItem)
 
 }
 
@@ -50,7 +49,8 @@ val inputComponent = FC<InputProps> { props ->
 private val scope = MainScope()
 
 val editComponent = FC<EditProps> { props ->
-    val (text, setText) = useState("")
+    val (text, setText) = useState(props.listItem.desc+"!".repeat(props.listItem.priority))
+
     val submitHandler: FormEventHandler<HTMLFormElement> = {
         it.preventDefault()
         setText("")
@@ -72,7 +72,7 @@ val editComponent = FC<EditProps> { props ->
         input {
             type = InputType.text
             onChange = changeHandler
-            value = props.name
+            value = text
         }
     }
 }

--- a/src/jvmMain/kotlin/Server.kt
+++ b/src/jvmMain/kotlin/Server.kt
@@ -85,7 +85,7 @@ fun main() {
                     call.respond(HttpStatusCode.OK)
                 }
                 put("/{id}") {
-                    val id = call.parameters["id"]?.toInt() ?: error("Invalid delete request")
+                    val id = call.parameters["id"]?.toInt() ?: error("Invalid edit request")
                     val listItemRequest= call.receive<ShoppingListItem>()
                     collection.updateOne(ShoppingListItem::id eq id, listItemRequest)
                 }


### PR DESCRIPTION
Fixed by adding creating editprop to pass into editcomponent that holds shoppinglistitem. It then changes the textfield to the desc. I used a .repeat call to put in the exclamation points too which was really cool. 
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/36392692/203186481-380ca784-06d5-4f16-86ed-d846cedf2c4b.png">
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/36392692/203186601-9ba5a184-2d32-46e4-a1d5-6d7e1704892e.png">
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/36392692/203186648-eab25406-1bfa-40cb-9db5-68d7a5571c8b.png">
Closes #21 
